### PR TITLE
(chore) fixed minor syntax error

### DIFF
--- a/app/code/StripeIntegration/Payments/Helper/Subscriptions.php
+++ b/app/code/StripeIntegration/Payments/Helper/Subscriptions.php
@@ -429,7 +429,7 @@ class Subscriptions
             }
         }
 
-        return $coupon->id;;
+        return $coupon->id;
     }
 
     public function createSubscriptionForProduct($product, $order, $item, $isDryRun, $trialEnd = null)


### PR DESCRIPTION
I found there was a double `;` in one of the files. Just found it out of a search I did for Stripe coupons and noticed it, hope you'll appreciate 🙌🏻 